### PR TITLE
Explicitly install graphql as a dev dep; run tests against v17 alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
     - run: npm ci
     - run: npm test
 
+  # This runs against an old alpha of GraphQL v17; hopefully Apollo Server v5
+  # will support the released version when they both come out.
+  graphql-17-alpha-incremental-delivery:
+    runs-on: ubuntu-latest
+    name: Test against GraphQL 17 alpha with incremental delivery
+    steps:
+    - uses: actions/checkout@v4
+    - uses: jdx/mise-action@v2
+    - uses: actions/setup-node@v4
+      with:
+        cache: 'npm'
+    - run: npm ci
+    - run: npm i --legacy-peer-deps graphql@17.0.0-alpha.2
+    - run: npm test
+      env:
+        INCREMENTAL_DELIVERY_TESTS_ENABLED: 't'
+
   prettier:
     runs-on: ubuntu-latest
     name: Prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cspell": "9.0.0",
         "eslint": "9.26.0",
         "express": "4.21.2",
+        "graphql": "16.11.0",
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
         "prettier": "3.5.3",
@@ -6783,7 +6784,6 @@
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cspell": "9.0.0",
     "eslint": "9.26.0",
     "express": "4.21.2",
+    "graphql": "16.11.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "prettier": "3.5.3",


### PR DESCRIPTION
Apollo Server v4 supports both graphql v16 and graphql with a specific (old now) alpha of graphql v17. We should test against both.

The environment variable unlocks some tests in
`@apollo/server-integration-testsuite` that are otherwise skipped.