### PR TITLE
fix: ensure that cleanup middleware are allowed to run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,8 @@ export function expressMiddleware<TContext extends BaseContext>(
           }
         }
         res.end();
-        next();
       })
+      .then(next)
       .catch(next);
   };
 }


### PR DESCRIPTION
Just a small change which allows middleware defined after ApolloServer to run. This also allows for better integration with at least some styles of integration testing under Express.